### PR TITLE
fix arguments to cl:apply in harmony-simple:decode

### DIFF
--- a/simple/default.lisp
+++ b/simple/default.lisp
@@ -58,7 +58,7 @@
 (defun decode (source-ish &rest initargs &key (server *server*) &allow-other-keys)
   (let ((initargs (copy-list initargs)))
     (remf initargs :server)
-    (apply #'harmony:decode source-ish initargs :samplerate (samplerate server))))
+    (apply #'harmony:decode source-ish :samplerate (samplerate server) initargs)))
 
 (defmethod add ((source source) (name symbol))
   (add source (ensure-segment name *server*)))


### PR DESCRIPTION
otherwise it errors saying "44100" is not a list.
see: http://clhs.lisp.se/Body/26_glo_s.htm#spreadable_argument_list_designator
and: http://clhs.lisp.se/Body/f_apply.htm