### PR TITLE
Fix default value for on-frame-change

### DIFF
--- a/segment.lisp
+++ b/segment.lisp
@@ -116,7 +116,7 @@
   ((repeat :initarg :repeat :initform 0 :accessor repeat)
    (repeat-start :initarg :repeat-start :initform 0 :accessor repeat-start)
    (on-end :initarg :on-end :initform #'default-source-end :accessor on-end)
-   (on-frame-change :initarg :on-frame-change :initform #'identity :accessor on-frame-change)))
+   (on-frame-change :initarg :on-frame-change :initform (constantly nil) :accessor on-frame-change)))
 
 (defmethod (setf mixed:done-p) :around (value (source source))
   (if value

--- a/segment.lisp
+++ b/segment.lisp
@@ -116,7 +116,7 @@
   ((repeat :initarg :repeat :initform 0 :accessor repeat)
    (repeat-start :initarg :repeat-start :initform 0 :accessor repeat-start)
    (on-end :initarg :on-end :initform #'default-source-end :accessor on-end)
-   (on-frame-change :initarg :on-frame-change :initform (constantly nil) :accessor on-frame-change)))
+   (on-frame-change :initarg :on-frame-change :initform (constantly NIL) :accessor on-frame-change)))
 
 (defmethod (setf mixed:done-p) :around (value (source source))
   (if value

--- a/segment.lisp
+++ b/segment.lisp
@@ -144,7 +144,8 @@
   (connect (mixed:unpacker from) from-loc to to-loc))
 
 (defmethod disconnect ((from source) from-loc &key (direction :output))
-  (disconnect (mixed:unpacker from) from-loc :direction direction))
+  (when (mixed:unpacker from)
+    (disconnect (mixed:unpacker from) from-loc :direction direction)))
 
 (defmethod mixed:volume ((source source))
   (mixed:volume (mixed:unpacker source)))


### PR DESCRIPTION
Instead of `#'identity` use `(constantly nil)` which can take two arguments.

And I'm not sure how to fix `disconnect` method. I see two solutions:
1) add default method:
```lisp
(defmethod disconnect (thing location &key (direction :output)))
```
2) check if the unpacker of source is set:
```lisp
(defmethod disconnect ((from source) from-loc &key (direction :output))
  (when (mixed:unpacker from)
    (disconnect (mixed:unpacker from) from-loc :direction direction)))
```