### PR TITLE
Fix harmony on CCL

### DIFF
--- a/environment.lisp
+++ b/environment.lisp
@@ -15,6 +15,7 @@
    (state :initform NIL :accessor state)))
 
 (defmethod shared-initialize :after ((environment environment) slots &key (sets NIL sets-p))
+  (declare (ignorable slots))
   (when sets-p
     (let* ((sources (delete-duplicates (loop for set in sets append (rest set)) :test #'equal))
            (source-table (make-hash-table :test 'equal))
@@ -121,6 +122,7 @@
   (apply #'call-next-method segment :on-end :call-track-end args))
 
 (defmethod shared-initialize :after ((segment music-segment) slots &key transition-points transition-interval (transition-offset 0))
+  (declare (ignorable slots))
   (when transition-points
     (let ((points (make-array (length transition-points) :element-type '(unsigned-byte 32) :initial-contents transition-points)))
       (setf (transition-fun segment)

--- a/environment.lisp
+++ b/environment.lisp
@@ -12,7 +12,7 @@
   ((segments :initform #() :accessor segments)
    (segment-sets :initform (make-hash-table :test 'eql) :accessor segment-sets)
    (next-index :initform 0 :accessor next-index)
-   (state :initform NIL :accessor state)))
+   (state :initform NIL :reader state)))
 
 (defmethod shared-initialize :after ((environment environment) slots &key (sets NIL sets-p))
   (declare (ignorable slots))

--- a/voice.lisp
+++ b/voice.lisp
@@ -145,9 +145,11 @@
     (connect (voice-end voice) T segment T)))
 
 (defmethod frame-change ((voice voice) old new)
+  (declare (ignorable old new))
   )
 
 (defmethod track-end ((voice voice) source)
+  (declare (ignorable source))
   )
 
 (defmethod source ((voice voice))


### PR DESCRIPTION
This requires a review for sure.

Atomics operations don't work on (slot-value ...) on ccl, but they work on sturcture slot (if I understand correctly).
Thus I created a simple `%ref` struct which will be stored in the slot, with list being stored inside this structure.

I am pretty sure that the name is awful + there is probably an existing library for that same thing + at the very least it shouldn't be defined in the environment.lisp file.